### PR TITLE
fixed filter operations

### DIFF
--- a/test/pages/datatable.page.js
+++ b/test/pages/datatable.page.js
@@ -1,0 +1,14 @@
+class DatatablePage {
+
+    get dataTable() {return $('table#example')}
+    get countryNames() { return $$(`//td[@class=' select-checkbox']/..//td[4]`)}
+    get employeeAges() { return $$(`//td[@class=' select-checkbox']/..//td[5]`) }
+
+    openApp() {
+        browser.maximizeWindow()
+        browser.url("https://datatables.net/extensions/select/examples/initialisation/checkbox.html")
+        return this.dataTable.waitForDisplayed()
+    }
+
+}
+module.exports=new DatatablePage()

--- a/test/specs/FilterOperations.js
+++ b/test/specs/FilterOperations.js
@@ -1,32 +1,32 @@
+const datapage = require('../pages/datatable.page')
+
 describe('Operations on a data table using filters', () => {
-
-    let countryNames = new Array()
-    let ages = new Array()
-    let set= new Array()
-
-    before(`Prerequisite`,()=>{
-        browser.maximizeWindow()
-        browser.url("https://datatables.net/extensions/select/examples/initialisation/checkbox.html")
-        countryNames = $$(`//td[@class=' select-checkbox']/..//td[4]`)
-        countryNames.forEach(country=>country.waitForDisplayed())
-        ages= $$(`//td[@class=' select-checkbox']/..//td[5]`)
-        ages.forEach(age=>age.waitForDisplayed())
-    })
     
+    let countryList = [];
+
+    before(`Prerequisite`, () => {
+        datapage.openApp()
+    })
+
     it('Get me the name of all the countries', () => {
-        console.log("Getting all the countries name:");
-        countryNames.forEach(country=>{
-            console.log(country.getText())
+        datapage.countryNames.filter(country => {
+            countryList.push(country.getText())
         })
+        console.log("Country List: ", countryList)
     })
 
-    it(`Get countries name whose length is odd`,()=>{
-        console.log("\nCountry names with odd length characters:")
-        set.filter(name=>name.length%2==1).forEach(name=>console.log(name))
+    it(`Get countries name whose length is odd`, () => {
+        const oddLengthCountryList = countryList.filter(name => name.length % 2 == 1);
+        console.log("Country with odd lenght: ", oddLengthCountryList)
     })
 
-    it(`Get count of the employes whose age > 21`,()=>{
-        console.log(ages.filter(age=>{
-            console.log(parseInt(age.getText())>21)}))
+    it(`Get unique country names`, () => {
+        const oddLengthCountryList = countryList.filter((item, index, elem) => elem.indexOf(item) === index)
+        console.log("Distinct Country List: ", oddLengthCountryList)
+    })
+
+    it(`Get count of the employes whose age > 21`, () => {
+        const countOfEmpGrtThan21 = datapage.employeeAges.filter(age => parseInt(age.getText())>21).length
+        console.log("Count of employee older than 21 years: ", countOfEmpGrtThan21)
     })
 })


### PR DESCRIPTION
**Issues**
Country names with odd length characters is returning true/false, it should return names
Country names with odd length characters was not printing anything
Get count of the employes whose age > 21 returning true/false and empty array

**changes**
fixed above issues
Used filter operation for all the operation
added block to print only distinct values
Created list for storing values as this can used in further validations (if required)

**Output after changes**
Country List:  [ 'Tokyo', 'London', 'San Francisco', 'London', 'San Francisco', 'New York', 'London', 'New York', 'New York', 'Edinburgh']
Country with odd lenght:  [ 'Tokyo', 'San Francisco', 'San Francisco', 'Edinburgh' ]
Distinct Country List:  [ 'Tokyo', 'London', 'San Francisco', 'New York', 'Edinburgh' ]
Count of employee older than 21 years:  9